### PR TITLE
Refactor bot server and cleanup deps

### DIFF
--- a/bot/index.ts
+++ b/bot/index.ts
@@ -1,12 +1,9 @@
 import express from "express";
-import bodyParser from "body-parser";
-import { google } from "googleapis";
-import config from "./config";
 import { TeamsBot } from "./teamsBot";
 
 const bot = new TeamsBot();
 const app = express();
-app.use(bodyParser.json());
+app.use(express.json());
 
 app.post("/chat", async (req, res) => {
   try {
@@ -19,7 +16,7 @@ app.post("/chat", async (req, res) => {
   }
 });
 
-const port = process.env.PORT || 3978;
+const port = Number(process.env.PORT) || 3978;
 app.listen(port, () => {
   console.log(`Server started on port ${port}`);
 });

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -716,42 +716,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
     "node_modules/botbuilder": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.18.0.tgz",
@@ -3509,40 +3473,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "requires": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
     },
     "botbuilder": {
       "version": "4.18.0",

--- a/bot/package.json
+++ b/bot/package.json
@@ -21,9 +21,7 @@
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
     "express": "^4.18.2",
-    "openai": "^3.1.0",
-    "googleapis": "^133.0.0",
-    "body-parser": "^1.20.2"
+    "openai": "^3.1.0"
   },
   "devDependencies": {
     "@types/restify": "8.4.2",

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -12,12 +12,18 @@ export class TeamsBot {
   }
 
   async handleMessage(text: string): Promise<string> {
-    const response = await this.openai.createCompletion({
-      model: "text-davinci-003",
-      prompt: text,
-      temperature: 0,
-      max_tokens: 2048,
-    });
-    return response.data.choices[0].text || "";
+    try {
+      const response = await this.openai.createCompletion({
+        model: "text-davinci-003",
+        prompt: text,
+        temperature: 0,
+        max_tokens: 2048,
+      });
+
+      return response.data.choices[0].text ?? "";
+    } catch (error) {
+      console.error("OpenAI request failed", error);
+      return "";
+    }
   }
 }


### PR DESCRIPTION
## Summary
- simplify Express setup
- add error handling to `TeamsBot`
- drop unused packages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6847b40dcc5c8327bf69cf497b795d8a