### PR TITLE
Rename bot to googlechat-mcp

### DIFF
--- a/.fx/configs/config.dev.json
+++ b/.fx/configs/config.dev.json
@@ -3,12 +3,12 @@
     "description": "You can customize the TeamsFx config for different environments. Visit https://aka.ms/teamsfx-env-config to learn more about this.",
     "manifest": {
         "appName": {
-            "short": "openai-teams-bot",
-            "full": "Full name for openai-teams-bot"
+            "short": "googlechat-mcp",
+            "full": "Full name for googlechat-mcp"
         },
         "description": {
-            "short": "Short description of openai-teams-bot",
-            "full": "Full description of openai-teams-bot"
+            "short": "Short description of googlechat-mcp",
+            "full": "Full description of googlechat-mcp"
         },
         "icons": {
             "color": "resources/color.png",

--- a/.fx/configs/projectSettings.json
+++ b/.fx/configs/projectSettings.json
@@ -1,5 +1,5 @@
 {
-    "appName": "openai-teams-bot",
+    "appName": "googlechat-mcp",
     "projectId": "7b645719-832e-4408-a185-7d1d52f4011e",
     "version": "2.1.0",
     "components": [

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# OpenAI Chat Bot
+# GoogleChat MCP Server
 
-See [bot/README.md](./bot/README.md) for instructions on running the Google Chat bot.
+This repository provides a GitHub MCP server that leverages the OpenAI API to power a Google Chat bot. See [bot/README.md](./bot/README.md) for instructions on running the bot.
 
-You could also try the [ChatGPT Teams Bot app](https://github.com/formulahendry/chatgpt-teams-bot) which uses latest `gpt-3.5-turbo` model. `Turbo` is the same model family that powers ChatGPT.
+You could also try the [ChatGPT Teams Bot app](https://github.com/formulahendry/chatgpt-teams-bot) which uses the latest `gpt-3.5-turbo` model. `Turbo` is the same model family that powers ChatGPT.
 
 ![OpenAI](./bot/images/openai-chat.png)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "openai-teams-bot",
+    "name": "googlechat-mcp",
     "version": "0.0.1",
     "description": "",
     "author": "",


### PR DESCRIPTION
## Summary
- rename project references to `googlechat-mcp`
- update README title and intro

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails to find dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6848cc33b2b083279006ba3bd0c5bafb