### PR TITLE
Add request validation

### DIFF
--- a/bot/__tests__/server.test.ts
+++ b/bot/__tests__/server.test.ts
@@ -21,5 +21,11 @@ describe('/chat endpoint', () => {
     expect(response.status).toBe(200);
     expect(response.body.text).toBe('pong');
   });
+
+  it('returns 400 when message text is missing', async () => {
+    const response = await request(app).post('/chat').send({});
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatch(/text is required/i);
+  });
 });
 

--- a/bot/index.ts
+++ b/bot/index.ts
@@ -7,7 +7,11 @@ app.use(express.json());
 
 app.post("/chat", async (req, res) => {
   try {
-    const text = req.body.message?.text || "";
+    const text = req.body.message?.text;
+    if (!text || typeof text !== "string" || text.trim() === "") {
+      res.status(400).json({ error: "Message text is required" });
+      return;
+    }
     const reply = await bot.handleMessage(text);
     res.json({ text: reply });
   } catch (error) {


### PR DESCRIPTION
## Summary
- validate req.body.message.text in Express route
- add jest test for missing message text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848cc89e73c83279792f4a3f42418c9