### PR TITLE
Remove unused env packages

### DIFF
--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -16,9 +16,7 @@
       },
       "devDependencies": {
         "@types/restify": "8.4.2",
-        "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",
-        "shx": "^0.3.3",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4"
       }
@@ -1136,22 +1134,6 @@
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-cmd": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
-      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^4.0.0",
-        "cross-spawn": "^7.0.0"
-      },
-      "bin": {
-        "env-cmd": "bin/env-cmd.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/escape-html": {
@@ -2433,22 +2415,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      },
-      "bin": {
-        "shx": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/side-channel": {
@@ -3806,16 +3772,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
-    "env-cmd": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
-      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
-      "dev": true,
-      "requires": {
-        "commander": "^4.0.0",
-        "cross-spawn": "^7.0.0"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4790,16 +4746,6 @@
             "path-is-absolute": "^1.0.0"
           }
         }
-      }
-    },
-    "shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
       }
     },
     "side-channel": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "scripts": {
-    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+    "dev:teamsfx": "npm run dev",
     "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
-    "build": "tsc --build && shx cp -r ./adaptiveCards ./lib/",
+    "build": "tsc --build && cp -r ./adaptiveCards ./lib/",
     "start": "node ./lib/index.js",
     "watch": "nodemon --exec \"npm run start\"",
     "test": "jest"
@@ -25,9 +25,7 @@
   },
   "devDependencies": {
     "@types/restify": "8.4.2",
-    "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7",
-    "shx": "^0.3.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",
     "jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- update dev/build scripts in bot/package.json
- drop `env-cmd` and `shx` from devDependencies
- clean package-lock

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848f1abda98832788997d7fde77297d