### PR TITLE
Remove unused config variables

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,8 +72,6 @@
             "command": "debug-set-up-bot",
             "args": {
                 //// Enter your own bot information if using the existing bot. ////
-                // "botId": "",
-                // "botPassword": "", // use plain text or environment variable reference like ${env:BOT_PASSWORD}
                 "botMessagingEndpoint": "/api/messages" // use your own routing "/any/path", or full URL "https://contoso.com/any/path"
             }
         },

--- a/bot/README.md
+++ b/bot/README.md
@@ -6,7 +6,6 @@ This bot exposes a `/chat` endpoint for [Google Chat](https://developers.google.
 
 - Node.js 18+
 - An OpenAI API key
-- A Google service account with access to the Chat API
 
 ## Setup
 
@@ -17,8 +16,6 @@ This bot exposes a `/chat` endpoint for [Google Chat](https://developers.google.
 2. Configure environment variables in `.env.local` or your shell:
    ```bash
    OPENAI_API_KEY=your_openai_key
-   GOOGLE_CLIENT_EMAIL=service-account-email@project.iam.gserviceaccount.com
-   GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
    PORT=3978 # optional
    ```
 3. Start the bot:

--- a/bot/config.ts
+++ b/bot/config.ts
@@ -1,9 +1,5 @@
 const config = {
-  botId: process.env.BOT_ID,
-  botPassword: process.env.BOT_PASSWORD,
   openaiApiKey: process.env.OPENAI_API_KEY,
-  googleClientEmail: process.env.GOOGLE_CLIENT_EMAIL,
-  googlePrivateKey: process.env.GOOGLE_PRIVATE_KEY,
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- strip unused configuration fields from bot config
- simplify docs and VS Code task comments

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot find module 'openai' etc.)*


------
https://chatgpt.com/codex/tasks/task_b_6848cc9e6d888327b39f9259b2335db8