### PR TITLE
Add FastAPI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # GoogleChat MCP Server
 
+This repository contains two components:
 
-See [bot/README.md](./bot/README.md) for instructions on running the Google Chat bot or integrating with the GitHub MCP server.
+1. **Google Chat Bot (Node.js)** – see [bot/README.md](./bot/README.md) for instructions on running the existing Express-based bot that integrates with the OpenAI API.
+2. **FastAPI MCP Server (Python)** – a lightweight server exposing Google Chat functionality as MCP tools.
 
-This repository provides a GitHub MCP server that leverages the OpenAI API to power a Google Chat bot. See [bot/README.md](./bot/README.md) for instructions on running the bot.
+The FastAPI server provides endpoints for sending messages, fetching users, and listing channels using Google OAuth credentials.  See [mcp_server/README.md](./mcp_server/README.md) for setup details.
 
-
-If you need a Microsoft Teams bot, see the [ChatGPT Teams Bot app](https://github.com/formulahendry/chatgpt-teams-bot) which uses the latest `gpt-3.5-turbo` model. `Turbo` is the same model family that powers ChatGPT.
-
-![OpenAI](./bot/images/openai-chat.png)
-
+If you need a Microsoft Teams bot, see the [ChatGPT Teams Bot app](https://github.com/formulahendry/chatgpt-teams-bot) which uses the latest `gpt-3.5-turbo` model.
 
 ![OpenAI](./bot/images/openai-chat.png)
-

--- a/bot/README.md
+++ b/bot/README.md
@@ -17,17 +17,12 @@ It also includes a `/mcp` endpoint for events from the [GitHub MCP server](https
 2. Configure environment variables in `.env.local` or your shell:
    ```bash
    OPENAI_API_KEY=your_openai_key
-
    GOOGLE_CLIENT_EMAIL=service-account-email@project.iam.gserviceaccount.com
- GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
-  PORT=3978 # optional
-  # optional: used when posting events from GitHub MCP server
-  MCP_SECRET=your_mcp_secret
-  ```
-=======
+   GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
    PORT=3978 # optional
+   # optional: used when posting events from GitHub MCP server
+   MCP_SECRET=your_mcp_secret
    ```
-
 3. Start the bot:
    ```bash
    npm run dev
@@ -35,8 +30,4 @@ It also includes a `/mcp` endpoint for events from the [GitHub MCP server](https
 4. Expose the port to the internet and configure the URL in your Google Chat app.
 5. If using the GitHub MCP server, configure it to POST events to `/mcp` with the shared secret.
 
-
 When Google Chat or MCP sends a message, the bot returns the OpenAI response generated using the ChatGPT model.
-
-When Google Chat sends a message, the bot returns the OpenAI response.
-

--- a/bot/googleChatBot.ts
+++ b/bot/googleChatBot.ts
@@ -18,16 +18,6 @@ export class GoogleChatBot {
         messages: [{ role: "user", content: text }],
         temperature: 0,
       });
-
-
-      return response.data.choices[0].message?.content ?? "";
-    } catch (error: any) {
-      console.error("OpenAI request failed", error?.message ?? error);
-      return "Sorry, something went wrong.";
-    }
-  }
-}
-
       return response.data.choices[0].message?.content ?? "";
     } catch (error: any) {
       console.error("OpenAI request failed", error.message || error);
@@ -35,5 +25,3 @@ export class GoogleChatBot {
     }
   }
 }
-
-

--- a/bot/index.ts
+++ b/bot/index.ts
@@ -1,10 +1,6 @@
 import express from "express";
 import { GoogleChatBot } from "./googleChatBot";
 
-
-const bot = new GoogleChatBot();
-const app = express();
-
 export const app = express();
 const bot = new GoogleChatBot();
 
@@ -25,7 +21,6 @@ app.post("/chat", async (req, res) => {
   }
 });
 
-
 app.post("/mcp", async (req, res) => {
   try {
     const text = req.body.text || "";
@@ -37,16 +32,9 @@ app.post("/mcp", async (req, res) => {
   }
 });
 
-const port = Number(process.env.PORT) || 3978;
-app.listen(port, () => {
-  console.log(`Server started on port ${port}`);
-});
-=======
 if (require.main === module) {
   const port = Number(process.env.PORT) || 3978;
   app.listen(port, () => {
     console.log(`Server started on port ${port}`);
   });
 }
-
-

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,0 +1,21 @@
+# FastAPI MCP Server
+
+This Python service exposes Google Chat functionality as simple tools for the MCP ecosystem.
+It uses Google OAuth service account credentials and provides three endpoints:
+
+- `POST /send_message` – send a text message to a space.
+- `POST /fetch_users` – retrieve members in a space.
+- `GET  /list_channels` – list spaces available to the bot.
+
+## Setup
+
+1. Create a service account in Google Cloud and enable the Chat API.
+2. Download the service account key JSON file and set `GOOGLE_SERVICE_ACCOUNT_FILE` to its path.
+3. Install dependencies and start the server:
+
+```bash
+pip install -r requirements.txt
+uvicorn mcp_server.main:app --reload
+```
+
+The service account must be added to the desired chat spaces so it can post messages and read membership information.

--- a/mcp_server/google_chat.py
+++ b/mcp_server/google_chat.py
@@ -1,0 +1,48 @@
+"""Wrapper functions for interacting with Google Chat."""
+from typing import List
+import os
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+SCOPES = [
+    "https://www.googleapis.com/auth/chat.bot",
+    "https://www.googleapis.com/auth/chat.readonly",
+    "https://www.googleapis.com/auth/chat.memberships.readonly",
+]
+
+SERVICE_ACCOUNT_FILE = os.environ.get("GOOGLE_SERVICE_ACCOUNT_FILE")
+
+
+def get_chat_service():
+    """Return an authorized Google Chat service client."""
+    if not SERVICE_ACCOUNT_FILE:
+        raise RuntimeError("GOOGLE_SERVICE_ACCOUNT_FILE env var not set")
+    credentials = service_account.Credentials.from_service_account_file(
+        SERVICE_ACCOUNT_FILE, scopes=SCOPES
+    )
+    return build("chat", "v1", credentials=credentials)
+
+
+def send_message(space_id: str, text: str) -> dict:
+    """Send a message to a Google Chat space."""
+    service = get_chat_service()
+    return (
+        service.spaces()
+        .messages()
+        .create(parent=f"spaces/{space_id}", body={"text": text})
+        .execute()
+    )
+
+
+def list_channels() -> List[dict]:
+    """List spaces available to the bot."""
+    service = get_chat_service()
+    resp = service.spaces().list().execute()
+    return resp.get("spaces", [])
+
+
+def fetch_users(space_id: str) -> List[dict]:
+    """Fetch members in a space."""
+    service = get_chat_service()
+    resp = service.spaces().members().list(parent=f"spaces/{space_id}").execute()
+    return resp.get("memberships", [])

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -1,0 +1,48 @@
+"""FastAPI server exposing Google Chat functions as MCP tools."""
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from . import google_chat
+
+app = FastAPI(title="Google Chat MCP Server")
+
+
+class MessageRequest(BaseModel):
+    space_id: str
+    text: str
+
+
+class SpaceRequest(BaseModel):
+    space_id: str
+
+
+@app.post("/send_message")
+async def send_message(req: MessageRequest):
+    try:
+        result = google_chat.send_message(req.space_id, req.text)
+        return {"message": result}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/fetch_users")
+async def fetch_users(req: SpaceRequest):
+    try:
+        users = google_chat.fetch_users(req.space_id)
+        return {"users": users}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.get("/list_channels")
+async def list_channels():
+    try:
+        spaces = google_chat.list_channels()
+        return {"channels": spaces}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("mcp_server.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+google-api-python-client
+google-auth

--- a/package.json
+++ b/package.json
@@ -1,17 +1,4 @@
 {
-t
-    "name": "openai-teams-bot",
-    "version": "0.0.1",
-    "description": "",
-    "author": "",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "devDependencies": {
-        "@microsoft/teamsfx-cli": "1.*"
-    },
-    "license": "MIT"
-=======
   "name": "googlechat-mcp",
   "version": "0.0.1",
   "description": "",
@@ -20,5 +7,4 @@ t
     "test": "npm --prefix bot test"
   },
   "license": "MIT"
-
 }


### PR DESCRIPTION
## Summary
- clean up Node bot source files
- add Python FastAPI MCP server exposing Google Chat tools
- document setup instructions for both bots
- fix root `package.json`

## Testing
- `python -m py_compile mcp_server/*.py`
- `npm --prefix bot test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a0f40fb9c8327934e6e67af92eb44