### PR TITLE
Cache Google Chat client

### DIFF
--- a/mcp_server/google_chat.py
+++ b/mcp_server/google_chat.py
@@ -3,6 +3,7 @@ from typing import List
 import os
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from google.auth.transport.requests import Request
 
 SCOPES = [
     "https://www.googleapis.com/auth/chat.bot",
@@ -13,14 +14,30 @@ SCOPES = [
 SERVICE_ACCOUNT_FILE = os.environ.get("GOOGLE_SERVICE_ACCOUNT_FILE")
 
 
-def get_chat_service():
-    """Return an authorized Google Chat service client."""
+_cached_service = None
+_cached_credentials = None
+
+
+def get_chat_service(refresh: bool = False):
+    """Return an authorized Google Chat service client.
+
+    Caches the service instance for reuse. Pass ``refresh=True`` to
+    refresh the underlying credentials token.
+    """
+    global _cached_service, _cached_credentials
+
     if not SERVICE_ACCOUNT_FILE:
         raise RuntimeError("GOOGLE_SERVICE_ACCOUNT_FILE env var not set")
-    credentials = service_account.Credentials.from_service_account_file(
-        SERVICE_ACCOUNT_FILE, scopes=SCOPES
-    )
-    return build("chat", "v1", credentials=credentials)
+
+    if _cached_service is None or _cached_credentials is None:
+        _cached_credentials = service_account.Credentials.from_service_account_file(
+            SERVICE_ACCOUNT_FILE, scopes=SCOPES
+        )
+        _cached_service = build("chat", "v1", credentials=_cached_credentials)
+    elif refresh:
+        _cached_credentials.refresh(Request())
+
+    return _cached_service
 
 
 def send_message(space_id: str, text: str) -> dict:

--- a/mcp_server/tests/test_google_chat.py
+++ b/mcp_server/tests/test_google_chat.py
@@ -1,0 +1,43 @@
+from unittest import mock
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import mcp_server.google_chat as google_chat
+
+
+def reset_cache():
+    google_chat._cached_service = None
+    google_chat._cached_credentials = None
+
+
+def test_get_chat_service_cached(monkeypatch):
+    monkeypatch.setattr(google_chat, "SERVICE_ACCOUNT_FILE", "/tmp/key.json")
+    reset_cache()
+    with mock.patch.object(google_chat.service_account, "Credentials") as cred_cls, \
+         mock.patch.object(google_chat, "build") as build_mock:
+        cred = mock.Mock()
+        cred_cls.from_service_account_file.return_value = cred
+        service = mock.Mock()
+        build_mock.return_value = service
+        s1 = google_chat.get_chat_service()
+        s2 = google_chat.get_chat_service()
+        assert s1 is s2
+        build_mock.assert_called_once()
+
+
+def test_get_chat_service_refresh(monkeypatch):
+    monkeypatch.setattr(google_chat, "SERVICE_ACCOUNT_FILE", "/tmp/key.json")
+    reset_cache()
+    with mock.patch.object(google_chat.service_account, "Credentials") as cred_cls, \
+         mock.patch.object(google_chat, "build") as build_mock:
+        cred = mock.Mock()
+        cred_cls.from_service_account_file.return_value = cred
+        service = mock.Mock()
+        build_mock.return_value = service
+        google_chat.get_chat_service()
+        google_chat.get_chat_service(refresh=True)
+        cred.refresh.assert_called_once()
+        build_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- reuse cached service account client
- allow credential refresh when needed
- add unit tests for chat client cache

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a1ad85d8883279492c42f8c2389b5