### PR TITLE
Fix README and config

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -17,17 +17,13 @@ It also includes a `/mcp` endpoint for events from the [GitHub MCP server](https
 2. Configure environment variables in `.env.local` or your shell:
    ```bash
    OPENAI_API_KEY=your_openai_key
-   GOOGLE_CLIENT_EMAIL=service-account-email@project.iam.gserviceaccount.com
-   GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
    PORT=3978 # optional
-   # optional: used when posting events from GitHub MCP server
-   MCP_SECRET=your_mcp_secret
    ```
 3. Start the bot:
    ```bash
    npm run dev
    ```
 4. Expose the port to the internet and configure the URL in your Google Chat app.
-5. If using the GitHub MCP server, configure it to POST events to `/mcp` with the shared secret.
+5. If using the GitHub MCP server, configure it to POST events to `/mcp`.
 
 When Google Chat or MCP sends a message, the bot returns the OpenAI response generated using the ChatGPT model.

--- a/bot/config.ts
+++ b/bot/config.ts
@@ -1,11 +1,5 @@
 const config = {
   openaiApiKey: process.env.OPENAI_API_KEY,
-
-  googleClientEmail: process.env.GOOGLE_CLIENT_EMAIL,
-  googlePrivateKey: process.env.GOOGLE_PRIVATE_KEY,
-  mcpSecret: process.env.MCP_SECRET,
-
-
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- remove unused Google credentials from bot
- update README for correct environment variables

## Testing
- `npm --prefix bot install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a1ac2b920832791ff81288541fc53