### PR TITLE
Improve async Google Chat server

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -7,6 +7,9 @@ It uses Google OAuth service account credentials and provides three endpoints:
 - `POST /fetch_users` – retrieve members in a space.
 - `GET  /list_channels` – list spaces available to the bot.
 
+All Google Chat API calls are run in a thread pool using FastAPI's
+`run_in_threadpool` helper so the async endpoints remain non-blocking.
+
 ## Setup
 
 1. Create a service account in Google Cloud and enable the Chat API.

--- a/mcp_server/google_chat.py
+++ b/mcp_server/google_chat.py
@@ -3,6 +3,7 @@ from typing import List
 import os
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from fastapi.concurrency import run_in_threadpool
 
 SCOPES = [
     "https://www.googleapis.com/auth/chat.bot",
@@ -34,6 +35,11 @@ def send_message(space_id: str, text: str) -> dict:
     )
 
 
+async def send_message_async(space_id: str, text: str) -> dict:
+    """Async wrapper for send_message using a thread pool."""
+    return await run_in_threadpool(send_message, space_id, text)
+
+
 def list_channels() -> List[dict]:
     """List spaces available to the bot."""
     service = get_chat_service()
@@ -41,8 +47,18 @@ def list_channels() -> List[dict]:
     return resp.get("spaces", [])
 
 
+async def list_channels_async() -> List[dict]:
+    """Async wrapper for list_channels using a thread pool."""
+    return await run_in_threadpool(list_channels)
+
+
 def fetch_users(space_id: str) -> List[dict]:
     """Fetch members in a space."""
     service = get_chat_service()
     resp = service.spaces().members().list(parent=f"spaces/{space_id}").execute()
     return resp.get("memberships", [])
+
+
+async def fetch_users_async(space_id: str) -> List[dict]:
+    """Async wrapper for fetch_users using a thread pool."""
+    return await run_in_threadpool(fetch_users, space_id)

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -18,7 +18,7 @@ class SpaceRequest(BaseModel):
 @app.post("/send_message")
 async def send_message(req: MessageRequest):
     try:
-        result = google_chat.send_message(req.space_id, req.text)
+        result = await google_chat.send_message_async(req.space_id, req.text)
         return {"message": result}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
@@ -27,7 +27,7 @@ async def send_message(req: MessageRequest):
 @app.post("/fetch_users")
 async def fetch_users(req: SpaceRequest):
     try:
-        users = google_chat.fetch_users(req.space_id)
+        users = await google_chat.fetch_users_async(req.space_id)
         return {"users": users}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
@@ -36,7 +36,7 @@ async def fetch_users(req: SpaceRequest):
 @app.get("/list_channels")
 async def list_channels():
     try:
-        spaces = google_chat.list_channels()
+        spaces = await google_chat.list_channels_async()
         return {"channels": spaces}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))


### PR DESCRIPTION
## Summary
- move synchronous Google Chat calls into a thread pool
- await threadpool wrappers in FastAPI endpoints
- document async behavior in `mcp_server` README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a194439308327b0be4f23e7613de6